### PR TITLE
Fix compilation errors vs2022

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,38 @@
+# Prerequisites
+*.d
+
+# Compiled Object files
+*.slo
+*.lo
+*.o
+*.obj
+
+# Precompiled Headers
+*.gch
+*.pch
+
+# Compiled Dynamic libraries
+*.so
+*.dylib
+*.dll
+
+# Fortran module files
+*.mod
+*.smod
+
+# Compiled Static libraries
+*.lai
+*.la
+*.a
+*.lib
+
+# Executables
+*.exe
+*.out
+*.app
+
+# Ignore IDE specific files
+.vscode/
+.vs/
+.idea/
+out/

--- a/G22_Example_2.cpp
+++ b/G22_Example_2.cpp
@@ -15,6 +15,7 @@
 #include <iostream>
 #include <span>
 #include <vector>
+#include <algorithm>
 
 void print( std::span<int> s )
 {

--- a/G33_Manual_Virtual_Dispatch.cpp
+++ b/G33_Manual_Virtual_Dispatch.cpp
@@ -70,7 +70,7 @@ class Shape
             []( void* shapeBytes ){
                using Model = OwningModel<ShapeT,DrawStrategy>;
                auto* const model = static_cast<Model*>(shapeBytes);
-               (*model->drawer_)( model->shape_ );
+               (model->drawer_)( model->shape_ );
             } )
       , clone_(
             []( void* shapeBytes ) -> void* {


### PR DESCRIPTION
* A small PR fixing compilation error for vs2022. 
* Added default `.gitignore` file from [here](https://github.com/github/gitignore/blob/main/C++.gitignore) with slight modification.